### PR TITLE
Log module run errors at module-exit time

### DIFF
--- a/service.go
+++ b/service.go
@@ -115,17 +115,16 @@ func execute(wg *ErrGroup, modules ...Module) {
 
 	for _, mod := range modules {
 		wg.Go(func() error {
-			defer func() {
-				slog.Info("module exited", slog.String("name", mod.ID()))
-				cancel()
-			}()
+			defer cancel()
 
 			slog.Info("module started", slog.String("name", mod.ID()))
 			err := catchPanic(mod.Run)
 			if err != nil {
+				slog.Error("module exited with error", slog.String("name", mod.ID()), slog.Any("error", err))
 				return fmt.Errorf("failed to run module %s: %w", mod.ID(), err)
 			}
 
+			slog.Info("module exited", slog.String("name", mod.ID()))
 			return nil
 		})
 	}


### PR DESCRIPTION
## Summary
- Run goroutines previously logged `module exited` without the error and only surfaced it later via the joined return value of `Run`. Failed modules were not identifiable from chronological logs.
- Log at `Error` level with the error attribute when Run returns non-nil. Keep the `Info` log on clean exit.
- Drop the wrapping `defer func` that only existed to log and cancel. `defer cancel()` is enough.

## Test plan
- [ ] `go test -race ./...` passes (run locally)
- [ ] CI green