### PR TITLE
Add optional StopTimeout to bound graceful-shutdown wait

### DIFF
--- a/service.go
+++ b/service.go
@@ -8,9 +8,22 @@ import (
 	"log/slog"
 	"os"
 	"runtime/debug"
+	"time"
 )
 
-const ErrModulePanic = ErrStr("module recovered from panic")
+const (
+	ErrModulePanic = ErrStr("module recovered from panic")
+	ErrStopTimeout = ErrStr("service stop timed out")
+)
+
+// StopTimeout, if greater than zero, bounds the time srvc.Run will wait
+// for the Stop sequence (and the remaining Run goroutines) to complete
+// after the first Run returns. On timeout, Run returns ErrStopTimeout
+// immediately. Remaining Stop/Run goroutines are detached and may leak,
+// so use RunAndExit to ensure the process exits in that case.
+//
+// Zero (the default) preserves the previous unbounded behavior.
+var StopTimeout time.Duration
 
 // exitFn allows patching the os.Exit function for testing purposes.
 var exitFn = os.Exit
@@ -80,16 +93,38 @@ func run(modules ...Module) error {
 		execute(wg, initialized...)
 	}
 
+	return JoinErrors(initErr, shutdown(wg, initialized))
+}
+
+func shutdown(wg *ErrGroup, initialized []Module) error {
+	if StopTimeout <= 0 {
+		return runShutdown(wg, initialized)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runShutdown(wg, initialized) }()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(StopTimeout):
+		slog.Error("service stop timed out", slog.Duration("timeout", StopTimeout))
+		return ErrStopTimeout
+	}
+}
+
+func runShutdown(wg *ErrGroup, initialized []Module) error {
 	slog.Info("stopping modules")
 	var stopErr error
 	for i := len(initialized) - 1; i >= 0; i-- {
 		mod := initialized[i]
 		slog.Info("module stopping", slog.String("name", mod.ID()))
-		stopErr = JoinErrors(stopErr, catchPanic(mod.Stop))
+		if err := catchPanic(mod.Stop); err != nil {
+			stopErr = JoinErrors(stopErr, fmt.Errorf("failed to stop module %s: %w", mod.ID(), err))
+		}
 		slog.Info("module stopped", slog.String("name", mod.ID()))
 	}
-
-	return JoinErrors(initErr, wg.Wait(), stopErr)
+	return JoinErrors(wg.Wait(), stopErr)
 }
 
 func initialize(modules ...Module) ([]Module, error) {

--- a/service_test.go
+++ b/service_test.go
@@ -93,6 +93,31 @@ func TestRun_NoModules(t *testing.T) {
 	}
 }
 
+func TestRun_StopTimeout(t *testing.T) {
+	srvc.StopTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { srvc.StopTimeout = 0 })
+
+	hang := make(chan struct{})
+	t.Cleanup(func() { close(hang) })
+
+	mod := &TestMod{
+		init: func() error { return nil },
+		run:  func() error { <-hang; return nil },
+		stop: func() error { <-hang; return nil },
+	}
+
+	stopMod, stop := StopMod()
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		stop()
+	}()
+
+	err := srvc.Run(mod, stopMod)
+	if !errors.Is(err, srvc.ErrStopTimeout) {
+		t.Errorf("expected ErrStopTimeout, got %v", err)
+	}
+}
+
 // StopMod can be used to trigger stop sequence for srvc.Run in tests.
 func StopMod() (srvc.Module, func()) {
 	ctx, stop := context.WithCancel(context.Background())


### PR DESCRIPTION
## Summary
A misbehaving module whose `Stop` hangs (or whose `Run` ignores `Stop`) currently hangs `srvc.Run` forever at the final wait, defeating the "avoid zombie services" goal.

Adds an opt-in `StopTimeout` package-level variable (matches the `JoinErrors` precedent). If `> 0`, `Run` returns `ErrStopTimeout` after that duration even if Stop/Run goroutines are still alive. Default `0` preserves current unbounded behavior.

Code path:
- `run()` delegates shutdown to a new `shutdown(...)` that races `runShutdown` against `time.After(StopTimeout)`.
- On timeout: log at error level, return `ErrStopTimeout`. Remaining goroutines are detached and will leak, so `RunAndExit` will then `os.Exit(1)` and kill the process.

Includes a `TestRun_StopTimeout` covering the timeout path.

## API design, please push back if this is wrong
Picked the smallest possible API: a package-level mutable global (`srvc.StopTimeout`). Pros: zero breaking change, mirrors the existing `srvc.JoinErrors` pattern. Cons: process-global state is ugly when multiple packages set it.

Alternatives considered:
- `srvc.RunWithTimeout(timeout time.Duration, modules ...Module) error`, nicer ergonomics but adds API surface.
- `srvc.RunCtx(ctx context.Context, modules ...Module)` where ctx deadline bounds shutdown, most Go-idiomatic, biggest change.

Happy to redo this as either if you prefer.

## Notes
- Diff overlaps slightly with #10 (Stop-error annotation) because the shutdown loop was refactored into its own function. Merge order: whichever lands last will need a trivial rebase, end state is the same.

## Test plan
- [ ] `go test -race ./...` passes (local)
- [ ] CI green
- [ ] `TestRun_StopTimeout` exercises the new code path