### PR TITLE
Polish godoc and add ExampleRun

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,18 @@
+package srvc_test
+
+import (
+	"fmt"
+
+	"github.com/go-srvc/srvc"
+)
+
+type printMod struct{}
+
+func (m *printMod) ID() string  { return "printMod" }
+func (m *printMod) Init() error { return nil }
+func (m *printMod) Run() error  { fmt.Println("hello"); return nil }
+func (m *printMod) Stop() error { return nil }
+
+func ExampleRun() {
+	_ = srvc.Run(&printMod{})
+}

--- a/group.go
+++ b/group.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 )
 
-// JoinErrors allows overwriting the default errors.JoinErrors function used by srvc package.
-// This can be useful for custom multi error formatting.
+// JoinErrors is used by srvc to combine multiple errors into one.
+// Override it to plug in custom multi-error formatting.
 var JoinErrors = errors.Join
 
 // ErrStr adds Error method to string type.

--- a/service.go
+++ b/service.go
@@ -22,8 +22,8 @@ type Module interface {
 	Init() error
 	// Run should start the module and block until stop is called or error occurs.
 	Run() error
-	// Stop allows synchronous cleanup of module should make Run() return eventually.
-	// If Init was called then Stop is guaranteed to be called as part of cleanup.
+	// Stop is called for synchronous cleanup and must cause Run to return.
+	// If Init ran, Stop is guaranteed to run as part of cleanup.
 	Stop() error
 }
 
@@ -38,8 +38,8 @@ type Module interface {
 //  5. Wait for all Run() goroutines to return.
 //  6. Return all errors or nil
 //
-// Possible panics inside modules are captured to allow graceful shutdown of other modules.
-// Captured panics are converted into errors and ErrPanic is returned.
+// Panics inside modules are recovered so other modules can shut down gracefully.
+// Recovered panics are returned as errors wrapping ErrModulePanic.
 func Run(modules ...Module) error {
 	slog.Info("starting service")
 	if err := run(modules...); err != nil {


### PR DESCRIPTION
## Summary
Small godoc fixes spotted while auditing the package.

- `Module.Stop` interface comment had broken grammar (`Stop allows synchronous cleanup of module should make Run() return eventually.`). Rewritten to a single clear sentence.
- `Run` package-level comment referenced `ErrPanic` (which does not exist). The actual sentinel is `ErrModulePanic`. Doc updated accordingly.
- `JoinErrors` doc referenced `errors.JoinErrors` (also does not exist). Default is `errors.Join`. Fixed and slightly tightened.
- Add `ExampleRun` so pkg.go.dev gets a runnable example next to `Run`.

No behavior change.

## Test plan
- [ ] go test -race ./... passes (local)
- [ ] make lint clean (local)
- [ ] CI green