### PR TITLE
Replace dependabot with weekly update-deps cron

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -1,0 +1,45 @@
+name: Update deps
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_TOKEN }}
+
+      - id: go
+        run: echo "version=$(curl -fsSL 'https://go.dev/dl/?mode=json' | jq -r '[.[] | select(.stable)] | .[0].version | sub("^go"; "")')" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.go.outputs.version }}
+
+      - name: Update Go, tools, and deps
+        run: make update-deps GO_VERSION=${{ steps.go.outputs.version }}
+
+      - name: Open PR if changes
+        env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: |
+          if git diff --quiet; then
+            echo "no changes"
+            exit 0
+          fi
+          git config user.name "go-srvc-bot"
+          git config user.email "go-srvc-bot@users.noreply.github.com"
+          git checkout -B update-deps
+          git add -A
+          git commit -m "Update Go, tools, and deps"
+          git push -f origin update-deps
+          gh pr view update-deps --json state -q .state 2>/dev/null | grep -q OPEN || \
+            gh pr create --title "Update Go, tools, and deps" --body "Weekly automated bump." --head update-deps --base main

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: test clean
 
+GO_VERSION ?= $(shell go env GOVERSION | sed 's/^go//')
+
 all: clean lint test
 
 .PHONY: lint
@@ -9,6 +11,13 @@ lint: ## Run linter
 .PHONY: test
 test: ## Run tests
 	go tool gotest.tools/gotestsum --junitfile=junit.xml -- -race -covermode=atomic -coverprofile=coverage.txt ./...
+
+.PHONY: update-deps
+update-deps: ## Update Go version, tools, and deps
+	go mod edit -go=${GO_VERSION}
+	go get -u -t ./...
+	go get -u tool
+	go mod tidy
 
 .PHONY: clean
 clean: ## Clean files

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Panics inside `Init`, `Run`, or `Stop` are recovered. The stack trace is logged,
 - `Stop` must make `Run` return. If `Run` ignores `Stop`, `srvc.Run` will block in its final wait. There is no built-in shutdown timeout, so a stuck module hangs the service.
 - `ID` should return a stable, unique identifier used for log attribution.
 
+### Why no context.Context on lifecycle methods?
+
+`Init`, `Run`, and `Stop` deliberately take no `context.Context`. Shutdown deadlines are already enforced by the platform the service runs on (Kubernetes `terminationGracePeriodSeconds`, systemd `TimeoutStopSec`, ECS `stopTimeout`), and a Go-side deadline cannot extend past the platform `SIGKILL`. Adding context plumbing to the interface would expand the surface without giving modules any extra safety. Modules that need a startup or shutdown budget for their own internal calls can take a context via their own options without changing `Module`.
+
 ## Acknowledgements
 
 This library is something I have found myself writing over and over again in every project I been part of. One of the iterations can be found under [https://github.com/elisasre/go-common](https://github.com/elisasre/go-common).


### PR DESCRIPTION
Mirrors the same pattern landed in `mods`: drop dependabot, replace with a single weekly cron that bumps the Go toolchain (latest stable from go.dev), tools, and deps in one PR. Requires `BOT_TOKEN` repo secret (PAT) so the bot-authored PR triggers CI.