### PR TITLE
Update only directs+tools and auto-merge update-deps PR

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -43,3 +43,4 @@ jobs:
           git push -f origin update-deps
           gh pr view update-deps --json state -q .state 2>/dev/null | grep -q OPEN || \
             gh pr create --title "Update Go, tools, and deps" --body "Weekly automated bump." --head update-deps --base main
+          gh pr merge update-deps --auto --squash

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,7 @@ test: ## Run tests
 .PHONY: update-deps
 update-deps: ## Update Go version, tools, and deps
 	go mod edit -go=${GO_VERSION}
-	go get -u -t ./...
-	go get -u tool
+	go get $$(go mod edit -json | jq -r '[(.Tool[]?.Path), (.Require[]? | select(.Indirect | not) | .Path)] | map(. + "@latest") | .[]')
 	go mod tidy
 
 .PHONY: clean


### PR DESCRIPTION
Two follow-ups to PR #20 that were lost on merge:

- Recipe targets only the `tool ()` packages and non-indirect `require ()` entries, then `go mod tidy` settles transitives at MVS minimums. Avoids the goheader v1.0.0 / golangci-lint v2.12.2 incompat that took out PR #22.
- Adds `gh pr merge update-deps --auto --squash` so the weekly bot PR self-merges once the required `build` check passes.