### PR TITLE
Trigger website Deploy on tag push

### DIFF
--- a/.github/workflows/trigger-website.yml
+++ b/.github/workflows/trigger-website.yml
@@ -1,0 +1,16 @@
+name: Trigger website
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: gh workflow run deploy.yml -R go-srvc/website


### PR DESCRIPTION
Adds a one-job workflow that fires `gh workflow run deploy.yml -R go-srvc/website` whenever a `v*` tag is pushed to this repo. Tags are typically created via GitHub releases (manual), so the push event will trigger normally.

Note: `BOT_TOKEN` needs `Actions: Read and write` on `go-srvc/website` to dispatch the deploy workflow.