### PR TITLE
Dispatch website Deploy after successful release build

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -68,3 +68,12 @@ jobs:
             ~/.cache/golangci-lint
             ~/.cache/go-build
             ~/go/pkg/mod
+
+  website:
+    if: ${{ github.event_name == 'release' }}
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.BOT_TOKEN }}
+        run: gh workflow run deploy.yml -R go-srvc/website

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -70,7 +70,7 @@ jobs:
             ~/go/pkg/mod
 
   website:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ env.IS_RELEASE }}
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds a `website` job in `go.yaml` that runs after `build` succeeds on a `release: published` event. Fires `gh workflow run deploy.yml -R go-srvc/website` so the site picks up the new tag.

Note: `BOT_TOKEN` needs `Actions: Read and write` on `go-srvc/website` for the dispatch to be authorized.