### PR TITLE
Auto-create GH Release and resolve tag once in tag job

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -109,25 +109,19 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Tag
-        run: make tag
-
       - id: tag
-        name: Resolve tag
-        run: echo "name=$(git tag --points-at HEAD --list 'v*' | head -1)" >> "$GITHUB_OUTPUT"
+        name: Tag
+        run: echo "name=$(make tag)" >> "$GITHUB_OUTPUT"
 
       - name: Push tag
-        if: steps.tag.outputs.name != ''
         run: git ls-remote --exit-code origin "refs/tags/${{ steps.tag.outputs.name }}" >/dev/null 2>&1 || git push origin "${{ steps.tag.outputs.name }}"
 
       - name: Create release
-        if: steps.tag.outputs.name != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release view "${{ steps.tag.outputs.name }}" >/dev/null 2>&1 || gh release create "${{ steps.tag.outputs.name }}" --generate-notes
 
       - name: Trigger website Deploy
-        if: steps.tag.outputs.name != ''
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: gh workflow run deploy.yml -R go-srvc/website

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -118,6 +118,14 @@ jobs:
           [ -z "$tag" ] && exit 0
           git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1 || git push origin "$tag"
 
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag=$(git tag --points-at HEAD --list 'v*' | head -1)
+          [ -z "$tag" ] && exit 0
+          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" --generate-notes
+
       - name: Trigger website Deploy
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -112,21 +112,22 @@ jobs:
       - name: Tag
         run: make tag
 
+      - id: tag
+        name: Resolve tag
+        run: echo "name=$(git tag --points-at HEAD --list 'v*' | head -1)" >> "$GITHUB_OUTPUT"
+
       - name: Push tag
-        run: |
-          tag=$(git tag --points-at HEAD --list 'v*' | head -1)
-          [ -z "$tag" ] && exit 0
-          git ls-remote --exit-code origin "refs/tags/$tag" >/dev/null 2>&1 || git push origin "$tag"
+        if: steps.tag.outputs.name != ''
+        run: git ls-remote --exit-code origin "refs/tags/${{ steps.tag.outputs.name }}" >/dev/null 2>&1 || git push origin "${{ steps.tag.outputs.name }}"
 
       - name: Create release
+        if: steps.tag.outputs.name != ''
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          tag=$(git tag --points-at HEAD --list 'v*' | head -1)
-          [ -z "$tag" ] && exit 0
-          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" --generate-notes
+        run: gh release view "${{ steps.tag.outputs.name }}" >/dev/null 2>&1 || gh release create "${{ steps.tag.outputs.name }}" --generate-notes
 
       - name: Trigger website Deploy
+        if: steps.tag.outputs.name != ''
         env:
           GH_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: gh workflow run deploy.yml -R go-srvc/website

--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,12 @@ api-check: ## Fail on breaking API changes vs the latest tag
 	go tool gorelease -base=${BASE}
 
 .PHONY: tag
-tag: ## Tag commit using gorelease's suggested version
+tag: ## Tag commit using gorelease's suggested version; prints version on stdout
 	@v="v1.0.0"; if [ -n "${LAST_TAG}" ]; then \
 	  v=$$(go tool gorelease -base=${LAST_TAG} | tee /dev/stderr | awk '/^Suggested version:/ {print $$3; exit}'); \
 	  test -n "$$v" || { echo "gorelease did not suggest a version" >&2; exit 1; }; \
 	fi; \
-	git tag "$$v" && echo "tagged $$v"
+	git tag "$$v" >&2 && echo "$$v"
 
 .PHONY: update-deps
 update-deps: ## Update Go version, tools, and deps


### PR DESCRIPTION
Follow-ups to #27 that didn't make it before the merge:

- Tag job creates a GH Release with auto-generated notes after pushing the tag.
- Tag is resolved once via `git tag --points-at HEAD` into a step output and reused by the Push/Release/Website-trigger steps, instead of being recomputed three times. Each step gates on `steps.tag.outputs.name != ''` so they skip cleanly when `make tag` decides nothing was tagable.